### PR TITLE
[FIX] Updated central-repo links in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Put a settings.xml into your ~/.m2 directory with the following content:
         <repository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <layout>default</layout>
           <snapshots><enabled>false</enabled></snapshots>
         </repository>
@@ -39,7 +39,7 @@ Put a settings.xml into your ~/.m2 directory with the following content:
         <pluginRepository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <layout>default</layout>
           <snapshots><enabled>false</enabled></snapshots>
           <releases><updatePolicy>never</updatePolicy></releases>


### PR DESCRIPTION
I was getting this error during building the project as per the instructions mentioned in the ReadMe.

![image](https://user-images.githubusercontent.com/22225798/78291820-b2b9c880-7543-11ea-8a40-d3dcc0752956.png)

The error was due to the required HTTPS for connecting to central-repo instead of HTTP. I have updated the links in the ReadMe to avoid build failures by new contributors.